### PR TITLE
Update the HTTPTypes dependency (#21)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "6861b096b0bd0cc339b9c5d34d55c665c7490703",
-        "version" : "0.2.0"
+        "revision" : "68deedb6b98837564cf0231fa1df48de35881993",
+        "version" : "0.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/swift-http-types.git", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", from: "0.2.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update documentation (#17)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Update the documentation and update unit tests (#16)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Added Documentation and HTTPField (#15)

* Clean up transformers (#12)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replace the HTTPHeader with HTTPField (#14)

* Clean up transformers (#12) (#13)

* Split the protocols

* Renamed result type

* Moved type to its file

* Replaced HTTPHeader with HTTPField

* Updated documentation and sample

* Latest Packages